### PR TITLE
Fixed telebow icon PitPack compatibility issues

### DIFF
--- a/PitExtras/index.js
+++ b/PitExtras/index.js
@@ -54,7 +54,7 @@ var timers = {
                       itemID:261,
                       enchantRequired:true,
                       defaultName:"§cTier III Bow",
-                      defaultLore: ["§dRARE! §9Telebow "],
+                      defaultLore: ["§dRARE! §9Telebow"],
                       defaultDamage:0,
                       cooldownLore: '§6Cooldown Remaining: '
                     }}


### PR DESCRIPTION
Removed the space from the end of the default lore for the Telebow icon for better compatibility with Pit texture packs